### PR TITLE
fix: Bug with silent fail and aarch64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -7,7 +7,7 @@ TOOL_NAME="vale"
 TOOL_TEST="vale --version"
 
 fail() {
-	echo -e "asdf-$TOOL_NAME: $*"
+	echo -e "asdf-$TOOL_NAME: $*" > /dev/stderr
 	exit 1
 }
 
@@ -26,6 +26,7 @@ get_arch() {
 	case $arch in
 	x86_64) arch="64-bit" ;;
 	arm64) arch="arm64" ;;
+ 	aarch64) arch="arm64" ;;
 	*) fail "The architecture (${arch}) is not supported by this installation script." ;;
 	esac
 	echo "$arch"


### PR DESCRIPTION
In Debian `get_arch` returns `aarch64` which then causes a failure. 
Unfortunately, because the failure happens during an assignment  it isn't surfaced to stderr.

This PR adds a mapping for `aarch64` -> `arm64` and fixes the silent fail but forcing the output to `/dev/stderr`.

Thanks to Stan Hu @ GitLab for troubleshooting and supplying the fix 🙏 